### PR TITLE
fix(dependencies) Add babel-eslint package as peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Add this package and its peerDependencies to your devDependencies
 ```bash
-npm i -D @clickagy/eslint-config eslint eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard
+npm i -D @clickagy/eslint-config eslint babel-eslint eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard
 ```
 
 Optionally, if using on a [Vue](https://vuejs.org/) or [Nuxt](https://nuxtjs.org/) project, also install `eslint-plugin-vue`

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "tape": "^4.9.1"
   },
   "peerDependencies": {
+    "babel-eslint": ">=10.0.1",
     "eslint": ">=5.12.1",
     "eslint-config-standard": ">=12.0.0",
     "eslint-plugin-import": ">=2.16.0",


### PR DESCRIPTION
Current config will not work without babel-eslint. As I understand, this parser need for some specific case and instruments (like [flow](https://flow.org/)). In the remaining cases, the standard parser will be compatible with Babel. But Nuxt use babel-eslint in example. So, keep using it :)